### PR TITLE
Bugfix of CMake create_symlink not working in Windows

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -92,7 +92,7 @@ if(ACID_LINK_RESOURCES)
 	get_filename_component(CURRENT_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
 	add_custom_command(TARGET Acid POST_BUILD
 			COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/Resources
-			COMMAND ${CMAKE_COMMAND} -E create_symlink ${CURRENT_PARENT_DIR}/Resources ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/Resources/Engine
+			COMMAND ${CMAKE_COMMAND} -E copy_directory ${CURRENT_PARENT_DIR}/Resources ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/Resources/Engine
 			)
 endif()
 


### PR DESCRIPTION
`create_symlink` is not a portable CMake command: it works on Linux and maybe on Mac but not on Windows.
As a replacement `copy_directory` should be used as suggested in the second comment on [this issue](https://github.com/flow123d/flow123d/issues/717)