### PR TITLE
Fixed a heap corruption caused by out of bounds array element assignm…

### DIFF
--- a/Sources/Fonts/msdf.c
+++ b/Sources/Fonts/msdf.c
@@ -762,6 +762,9 @@ float* ex_msdf_glyph(stbtt_fontinfo *font, uint32_t c, size_t w, size_t h, ex_me
         j++;
       }
 
+	  if (j >= contour_count)
+		  break;
+
       contours[j].start = i;
     } else if (i >= num_verts) {
       contours[j].end = i;


### PR DESCRIPTION
…ent.
In the case when contour_count == 1 the j variable got incremented to 1 and the value of variable i was assigned into unallocated memory causing heap corruption (crashed when variable contours was freed at the end of the function)